### PR TITLE
Fix drift management

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -32,6 +32,4 @@
             "baked_commit_ref": "b734d153c61ac62f0073329155291b8ffb86440f"
         }
     }
-  }
 }
-

--- a/changes/100.housekeeping
+++ b/changes/100.housekeeping
@@ -1,0 +1,1 @@
+Fixed malformed `.cookiecutter.json` file.


### PR DESCRIPTION
# Closes Nan

Drift management is blocked by malformed `.cookiecutter.json` file. This PR fixes the issue.

## What's Changed

- Fixed malformed `.cookiecutter.json` file.
