### PR TITLE
Bump to v2.0.1

### DIFF
--- a/changes/100.changed
+++ b/changes/100.changed
@@ -1,1 +1,0 @@
-Replaced pydocstyle with ruff.

--- a/changes/100.housekeeping
+++ b/changes/100.housekeeping
@@ -1,1 +1,0 @@
-Fixed malformed `.cookiecutter.json` file.

--- a/changes/103.housekeeping
+++ b/changes/103.housekeeping
@@ -1,1 +1,0 @@
-Updated from `nautobot-app-v2.2.0`.

--- a/changes/104.housekeeping
+++ b/changes/104.housekeeping
@@ -1,1 +1,0 @@
-Re-baked from the template `nautobot-app-v2.2.1`.

--- a/docs/admin/release_notes/version_2.0.md
+++ b/docs/admin/release_notes/version_2.0.md
@@ -7,3 +7,19 @@
 ### Changed
 
 - [#85](https://github.com/nautobot/nautobot-app-welcome-wizard/pull/85) Updates for Nautobot v2
+
+## [v2.0.1 (2024-04-11)](https://github.com/nautobot/nautobot-app-welcome-wizard/releases/tag/v2.0.0)
+
+### Changed
+
+- [#100](https://github.com/nautobot/nautobot-app-welcome-wizard/issues/100) - Replaced pydocstyle with ruff.
+
+### Fixed
+
+- [#94](https://github.com/nautobot/nautobot-app-welcome-wizard/issues/94) - Remove Sites and Device Roles from Merlin objects.
+
+### Housekeeping
+
+- [#100](https://github.com/nautobot/nautobot-app-welcome-wizard/issues/100) - Fixed malformed `.cookiecutter.json` file.
+- [#103](https://github.com/nautobot/nautobot-app-welcome-wizard/issues/103) - Updated from `nautobot-app-v2.2.0`.
+- [#104](https://github.com/nautobot/nautobot-app-welcome-wizard/issues/104) - Re-baked from the template `nautobot-app-v2.2.1`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-welcome-wizard"
-version = "2.0.0"
+version = "2.0.1"
 description = "Nautobot's Getting Started Wizard"
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"

--- a/welcome_wizard/migrations/0005_fix_sites_and_roles_in_merlin.py
+++ b/welcome_wizard/migrations/0005_fix_sites_and_roles_in_merlin.py
@@ -5,11 +5,11 @@ from welcome_wizard.models.merlin import Merlin
 
 
 def remove_device_roles(welcome_wizard, schema):
-    Merlin.objects.filter(name="Sites").delete()
+    Merlin.objects.filter(name="Device Roles").delete()
 
 
 def remove_sites(welcome_wizard, schema):
-    Merlin.objects.filter(name="Device Roles").delete()
+    Merlin.objects.filter(name="Sites").delete()
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
## [v2.0.1 (2024-04-11)](https://github.com/nautobot/nautobot-app-welcome-wizard/releases/tag/v2.0.0)

### Changed

- [#100](https://github.com/nautobot/nautobot-app-welcome-wizard/issues/100) - Replaced pydocstyle with ruff.

### Fixed

- [#94](https://github.com/nautobot/nautobot-app-welcome-wizard/issues/94) - Remove Sites and Device Roles from Merlin objects.

### Housekeeping

- [#100](https://github.com/nautobot/nautobot-app-welcome-wizard/issues/100) - Fixed malformed `.cookiecutter.json` file.
- [#103](https://github.com/nautobot/nautobot-app-welcome-wizard/issues/103) - Updated from `nautobot-app-v2.2.0`.
- [#104](https://github.com/nautobot/nautobot-app-welcome-wizard/issues/104) - Re-baked from the template `nautobot-app-v2.2.1`.